### PR TITLE
Accept String and Symbol in arguments of GeoIP2LookupResult#get_value

### DIFF
--- a/ext/geoip2/extconf.rb
+++ b/ext/geoip2/extconf.rb
@@ -3,6 +3,7 @@ require "mkmf"
 dir_config("maxminddb")
 have_header("maxminddb.h")
 have_library("maxminddb")
+have_func("rb_sym2str", "ruby.h")
 
 $CFLAGS << " -std=c99"
 # $CFLAGS << " -g -O0"

--- a/ext/geoip2/geoip2.c
+++ b/ext/geoip2/geoip2.c
@@ -1,6 +1,7 @@
 #include <ruby.h>
 #include <ruby/encoding.h>
 #include <maxminddb.h>
+#include "rb_compat.h"
 
 VALUE rb_mGeoIP2;
 VALUE rb_cGeoIP2Database;
@@ -310,9 +311,7 @@ static inline char*
 rb_geoip_convert_to_string(VALUE object)
 {
   if (TYPE(object) == T_SYMBOL) {
-    // TODO: Use rb_sym2str() instead of rb_id2str(SYM2ID()) when
-    // dropping Ruby 2.1 support.
-    return RSTRING_PTR(rb_id2str(SYM2ID(object)));
+    return RSTRING_PTR(SYM2STR(object));
   } else {
     return StringValueCStr(object);
   }

--- a/ext/geoip2/geoip2.c
+++ b/ext/geoip2/geoip2.c
@@ -308,12 +308,12 @@ rb_geoip2_lr_initialize(VALUE self)
 }
 
 static inline char*
-rb_geoip_convert_to_string(VALUE object)
+rb_geoip2_lr_arg_convert_to_cstring(VALUE sym_or_str)
 {
-  if (TYPE(object) == T_SYMBOL) {
-    return RSTRING_PTR(SYM2STR(object));
+  if (TYPE(sym_or_str) == T_SYMBOL) {
+    return RSTRING_PTR(SYM2STR(sym_or_str));
   } else {
-    return StringValueCStr(object);
+    return StringValueCStr(sym_or_str);
   }
 }
 
@@ -349,11 +349,11 @@ rb_geoip2_lr_get_value(int argc, VALUE *argv, VALUE self)
                        &rb_lookup_result_type,
                        result);
 
-  path[i] = rb_geoip_convert_to_string(arg);
+  path[i] = rb_geoip2_lr_arg_convert_to_cstring(arg);
   while (RARRAY_LEN(rest) != 0) {
     ++i;
     e = rb_ary_shift(rest);
-    tmp = rb_geoip_convert_to_string(e);
+    tmp = rb_geoip2_lr_arg_convert_to_cstring(e);
     path[i] = tmp;
   }
 

--- a/ext/geoip2/geoip2.c
+++ b/ext/geoip2/geoip2.c
@@ -311,7 +311,7 @@ static inline char*
 rb_geoip2_lr_arg_convert_to_cstring(VALUE sym_or_str)
 {
   if (TYPE(sym_or_str) == T_SYMBOL) {
-    return RSTRING_PTR(SYM2STR(sym_or_str));
+    return RSTRING_PTR(rb_sym2str(sym_or_str));
   } else {
     return StringValueCStr(sym_or_str);
   }

--- a/ext/geoip2/rb_compat.h
+++ b/ext/geoip2/rb_compat.h
@@ -4,9 +4,7 @@
 #include <ruby.h>
 
 #ifndef HAVE_RB_SYM2STR
-#  define SYM2STR(name) (rb_id2str(SYM2ID(name)))
-#else
-#  define SYM2STR(name) (rb_sym2str(name))
+#  define rb_sym2str(name) (rb_id2str(SYM2ID(name)))
 #endif
 
 #endif

--- a/ext/geoip2/rb_compat.h
+++ b/ext/geoip2/rb_compat.h
@@ -1,0 +1,12 @@
+#ifndef __RB_COMPAT_H__
+#define __RB_COMPAT_H__
+
+#include <ruby.h>
+
+#ifndef HAVE_RB_SYM2STR
+#  define SYM2STR(name) (rb_id2str(SYM2ID(name)))
+#else
+#  define SYM2STR(name) (rb_sym2str(name))
+#endif
+
+#endif

--- a/test/test_geoip2.rb
+++ b/test/test_geoip2.rb
@@ -27,40 +27,80 @@ class GeoIP2Test < Test::Unit::TestCase
       @db.close
     end
 
-    data do
-      random_ip_data("::81.2.69.142/127")
-    end
-    test "London" do |ip|
-      result = @db.lookup(ip)
-      expected = {
-        city_name: "London",
-        city_geoname_id: 2643743,
-        continent_code: "EU",
-      }
-      actual = {
-        city_name: result.get_value("city", "names", "en"),
-        city_geoname_id: result.get_value("city", "geoname_id"),
-        continent_code: result.get_value("continent", "code"),
-      }
-      assert_equal(expected, actual)
+    sub_test_case "with String arguments" do
+      data do
+        random_ip_data("::81.2.69.142/127")
+      end
+      test "London" do |ip|
+        result = @db.lookup(ip)
+        expected = {
+          city_name: "London",
+          city_geoname_id: 2643743,
+          continent_code: "EU",
+        }
+        actual = {
+          city_name: result.get_value("city", "names", "en"),
+          city_geoname_id: result.get_value("city", "geoname_id"),
+          continent_code: result.get_value("continent", "code"),
+        }
+        assert_equal(expected, actual)
+      end
+
+      test "city.names is a Hash" do
+        result = @db.lookup("81.2.69.142")
+        assert_instance_of(Hash, result.get_value("city", "names"))
+      end
+
+      test "subdivisions is an Array" do
+        result = @db.lookup("81.2.69.142")
+        assert_instance_of(Array, result.get_value("subdivisions"))
+      end
+
+      data do
+        random_ip_data("127.0.0.0/24")
+          .merge(random_ip_data("192.168.0.0/24"))
+      end
+      test "cannot find IPv4 private address" do |ip|
+        assert_nil(@db.lookup(ip))
+      end
     end
 
-    test "city.names is a Hash" do
-      result = @db.lookup("81.2.69.142")
-      assert_instance_of(Hash, result.get_value("city", "names"))
-    end
+    sub_test_case "with Symbol arguments" do
+      data do
+        random_ip_data("::81.2.69.142/127")
+      end
+      test "London" do |ip|
+        result = @db.lookup(ip)
+        expected = {
+          city_name: "London",
+          city_geoname_id: 2643743,
+          continent_code: "EU",
+        }
+        actual = {
+          city_name: result.get_value(:city, :names, :en),
+          city_geoname_id: result.get_value(:city, :geoname_id),
+          continent_code: result.get_value(:continent, :code),
+        }
+        assert_equal(expected, actual)
+      end
 
-    test "subdivisions is an Array" do
-      result = @db.lookup("81.2.69.142")
-      assert_instance_of(Array, result.get_value("subdivisions"))
-    end
+      test "city.names is a Hash" do
+        result = @db.lookup("81.2.69.142")
+        assert_instance_of(Hash, result.get_value(:city, :names))
+      end
 
-    data do
-      random_ip_data("127.0.0.0/24")
-        .merge(random_ip_data("192.168.0.0/24"))
-    end
-    test "cannot find IPv4 private address" do |ip|
-      assert_nil(@db.lookup(ip))
+      test "subdivisions is an Array" do
+        result = @db.lookup("81.2.69.142")
+        assert_instance_of(Array, result.get_value(:subdivisions))
+      end
+
+      data do
+        random_ip_data("127.0.0.0/24")
+          .merge(random_ip_data("192.168.0.0/24"))
+      end
+      test "cannot find IPv4 private address" do |ip|
+        assert_nil(@db.lookup(ip))
+      end
     end
   end
 
@@ -147,41 +187,82 @@ class GeoIP2Test < Test::Unit::TestCase
       @db.close
     end
 
-    data do
-      random_ip_data("2001:218::/32")
-        .merge(random_ip_data("2001:240::/32"))
-    end
-    test "Japan" do |ip|
-      result = @db.lookup(ip)
-      expected = {
-        continent_code: "AS",
-        country_iso_code: "JP",
-        country_name_en: "Japan"
-      }
-      actual = {
-        continent_code: result.get_value("continent", "code"),
-        country_iso_code: result.get_value("country", "iso_code"),
-        country_name_en: result.get_value("country", "names", "en")
-      }
-      assert_equal(expected, actual)
+    sub_test_case "with String arguments" do
+      data do
+        random_ip_data("2001:218::/32")
+          .merge(random_ip_data("2001:240::/32"))
+      end
+      test "Japan" do |ip|
+        result = @db.lookup(ip)
+        expected = {
+          continent_code: "AS",
+          country_iso_code: "JP",
+          country_name_en: "Japan"
+        }
+        actual = {
+          continent_code: result.get_value("continent", "code"),
+          country_iso_code: result.get_value("country", "iso_code"),
+          country_name_en: result.get_value("country", "names", "en")
+        }
+        assert_equal(expected, actual)
+      end
+
+      data do
+        random_ip_data("::89.160.20.128/121")
+      end
+      test "Sweden" do |ip|
+        result = @db.lookup(ip)
+        expected = {
+          continent_code: "EU",
+          country_iso_code: "SE",
+          country_name_en: "Sweden"
+        }
+        actual = {
+          continent_code: result.get_value("continent", "code"),
+          country_iso_code: result.get_value("country", "iso_code"),
+          country_name_en: result.get_value("country", "names", "en")
+        }
+        assert_equal(expected, actual)
+      end
     end
 
-    data do
-      random_ip_data("::89.160.20.128/121")
-    end
-    test "Sweden" do |ip|
-      result = @db.lookup(ip)
-      expected = {
-        continent_code: "EU",
-        country_iso_code: "SE",
-        country_name_en: "Sweden"
-      }
-      actual = {
-        continent_code: result.get_value("continent", "code"),
-        country_iso_code: result.get_value("country", "iso_code"),
-        country_name_en: result.get_value("country", "names", "en")
-      }
-      assert_equal(expected, actual)
+    sub_test_case "with Symbol arguments" do
+      data do
+        random_ip_data("2001:218::/32")
+          .merge(random_ip_data("2001:240::/32"))
+      end
+      test "Japan" do |ip|
+        result = @db.lookup(ip)
+        expected = {
+          continent_code: "AS",
+          country_iso_code: "JP",
+          country_name_en: "Japan"
+        }
+        actual = {
+          continent_code: result.get_value(:continent, :code),
+          country_iso_code: result.get_value(:country, :iso_code),
+          country_name_en: result.get_value(:country, :names, :en)
+        }
+        assert_equal(expected, actual)
+      end
+
+      data do
+        random_ip_data("::89.160.20.128/121")
+      end
+      test "Sweden" do |ip|
+        result = @db.lookup(ip)
+        expected = {
+          continent_code: "EU",
+          country_iso_code: "SE",
+          country_name_en: "Sweden"
+        }
+        actual = {
+          continent_code: result.get_value(:continent, :code),
+          country_iso_code: result.get_value(:country, :iso_code),
+          country_name_en: result.get_value(:country, :names, :en)
+        }
+        assert_equal(expected, actual)
+      end
     end
   end
 end


### PR DESCRIPTION
Ruby 2.1.* does not have `rb_sym2str()` C API function.
So, I added a kind of existence checking for it.