### PR TITLE
Add MMDB_UINT128_IS_BYTE_ARRAY constant existence checking

### DIFF
--- a/ext/geoip2/geoip2.c
+++ b/ext/geoip2/geoip2.c
@@ -135,8 +135,11 @@ mmdb_entry_data_decode(MMDB_entry_data_s *entry_data)
   case MMDB_DATA_TYPE_UINT64:
     return UINT2NUM(entry_data->uint64);
   case MMDB_DATA_TYPE_UINT128:
-    /* FIXME I'm not sure */
+#if !(MMDB_UINT128_IS_BYTE_ARRAY)
     return UINT2NUM(entry_data->uint128);
+#else
+    rb_raise(rb_eNotImpError, "TODO: unit8_t[16] -> Integer");
+#endif
   case MMDB_DATA_TYPE_ARRAY:
     /* TODO: not implemented */
     return Qnil;


### PR DESCRIPTION
`UINT2NUM` macro already considers big integer: https://github.com/ruby/ruby/blob/c047f58da658ee25b5d110e274daa6ca172e6aae/include/ruby/ruby.h#L1506-L1531

I'm not sure how to initialize Ruby's BigDecimal class in C world. :(
So, I decided to raise exception when system does not have `unsigned ___int128` type.
(Recent systems almost have this type.)