### PR TITLE
Fix memory leak

### DIFF
--- a/ext/geoip2/geoip2.c
+++ b/ext/geoip2/geoip2.c
@@ -30,13 +30,15 @@ static VALUE rb_geoip2_lr_to_h(VALUE self);
 static const rb_data_type_t rb_mmdb_type = {
   "geoip2/mmdb", {
     0, mmdb_free, 0,
-  }, NULL, NULL
+  }, NULL, NULL,
+  RUBY_TYPED_FREE_IMMEDIATELY
 };
 
 static const rb_data_type_t rb_lookup_result_type = {
   "geoip2/lookup_result", {
     0, 0, 0,
-  }, NULL, NULL
+  }, NULL, NULL,
+  RUBY_TYPED_FREE_IMMEDIATELY
 };
 
 static void

--- a/ext/geoip2/geoip2.c
+++ b/ext/geoip2/geoip2.c
@@ -36,7 +36,7 @@ static const rb_data_type_t rb_mmdb_type = {
 
 static const rb_data_type_t rb_lookup_result_type = {
   "geoip2/lookup_result", {
-    0, 0, 0,
+    0, RUBY_DEFAULT_FREE, 0,
   }, NULL, NULL,
   RUBY_TYPED_FREE_IMMEDIATELY
 };


### PR DESCRIPTION
In previous version, the Ruby process consumes about 480MB memory after this library via fluent-plugin-geoip processes 900M IP addresses.
In this version, the Ruby process consumes about 90MB memory after this library via fluent-plugin-geoip processes 1500M IP addresses.

The memory leak is not caused by the cache mechanism.

Fix #8 