### PR TITLE
Add GeoIP2::LookupResult#netmask

### DIFF
--- a/ext/geoip2/geoip2.c
+++ b/ext/geoip2/geoip2.c
@@ -396,6 +396,19 @@ rb_geoip2_lr_get_value(int argc, VALUE *argv, VALUE self)
 }
 
 static VALUE
+rb_geoip2_lr_netmask(VALUE self)
+{
+  MMDB_lookup_result_s *result = NULL;
+
+  TypedData_Get_Struct(self,
+                       struct MMDB_lookup_result_s,
+                       &rb_lookup_result_type,
+                       result);
+
+  return UINT2NUM(result->netmask);
+}
+
+static VALUE
 rb_geoip2_lr_to_h(VALUE self)
 {
   MMDB_lookup_result_s *result = NULL;
@@ -449,5 +462,6 @@ Init_geoip2(void)
   rb_define_alloc_func(rb_cGeoIP2LookupResult, rb_geoip2_lr_alloc);
   rb_define_method(rb_cGeoIP2LookupResult, "initialize", rb_geoip2_lr_initialize, 0);
   rb_define_method(rb_cGeoIP2LookupResult, "get_value", rb_geoip2_lr_get_value, -1);
+  rb_define_method(rb_cGeoIP2LookupResult, "netmask", rb_geoip2_lr_netmask, 0);
   rb_define_method(rb_cGeoIP2LookupResult, "to_h", rb_geoip2_lr_to_h, 0);
 }

--- a/test/test_geoip2.rb
+++ b/test/test_geoip2.rb
@@ -123,6 +123,7 @@ class GeoIP2Test < Test::Unit::TestCase
         "is_anonymous_vpn" => true
       }
       assert_equal(expected, result.to_h)
+      assert_equal(112, result.netmask)
     end
 
     data do
@@ -135,6 +136,7 @@ class GeoIP2Test < Test::Unit::TestCase
         "is_tor_exit_node" => true
       }
       assert_equal(expected, result.to_h)
+      assert_equal(109, result.netmask)
     end
   end
 


### PR DESCRIPTION
This PR simply exposes `result->netmask` into LookupResult.