### PR TITLE
Symbolize keys

### DIFF
--- a/ext/geoip2/extconf.rb
+++ b/ext/geoip2/extconf.rb
@@ -14,10 +14,10 @@ if !File.directory?(maxminddb_dir) ||
 end
 
 Dir.chdir(maxminddb_dir) do
-  system("./bootstrap")
-  system({ "CFLAGS" => "-fPIC" }, "./configure", "--disable-shared", "--disable-tests")
-  system("make", "clean")
-  system("make")
+  system("./bootstrap") or fail "Couldn't run maxminddb `bootstrap`"
+  system({ "CFLAGS" => "-fPIC" }, "./configure", "--disable-shared", "--disable-tests") or fail "Couldn't run maxminddb `configure`"
+  system("make", "clean") or fail "Couldn't run maxminddb `make clean`"
+  system("make") or fail "Couldn't run maxminddb `make`"
 end
 
 header_dirs = [includedir, "#{maxminddb_dir}/include"]

--- a/ext/geoip2/extconf.rb
+++ b/ext/geoip2/extconf.rb
@@ -5,6 +5,13 @@ libdir = RbConfig::CONFIG["libdir"]
 includedir = RbConfig::CONFIG["includedir"]
 
 maxminddb_dir = File.expand_path(File.join(__dir__, "libmaxminddb"))
+gem_root = File.expand_path('..', __dir__)
+
+if !File.directory?(maxminddb_dir) ||
+   # '.', '..', and possibly '.git' from a failed checkout:
+   Dir.entries(maxminddb_dir).size <= 3
+  Dir.chdir(gem_root) { system('git submodule update --init') } or fail 'Could not fetch maxminddb'
+end
 
 Dir.chdir(maxminddb_dir) do
   system("./bootstrap")

--- a/ext/geoip2/geoip2.c
+++ b/ext/geoip2/geoip2.c
@@ -256,20 +256,10 @@ rb_geoip2_db_alloc(VALUE klass)
 }
 
 static VALUE
-rb_geoip2_db_initialize(int argc, VALUE* argv, VALUE self)
+rb_geoip2_db_open_mmdb(VALUE self, VALUE path)
 {
-  VALUE path;
-  VALUE opts;
-  VALUE symbolize_keys;
   char *db_path;
   MMDB_s *mmdb;
-  ID keyword_ids[1];
-  keyword_ids[0] = rb_intern("symbolize_keys");
-
-  rb_scan_args(argc, argv, "1:", &path, &opts);
-  if (NIL_P(opts)) opts = rb_hash_new();
-  rb_get_kwargs(opts, keyword_ids, 0, 1, &symbolize_keys);
-  rb_iv_set(self, "@symbolize_keys", symbolize_keys);
 
   Check_Type(path, T_STRING);
 
@@ -494,7 +484,7 @@ Init_geoip2(void)
   rb_eGeoIP2Error = rb_define_class_under(rb_mGeoIP2, "Error", rb_eStandardError);
 
   rb_define_alloc_func(rb_cGeoIP2Database, rb_geoip2_db_alloc);
-  rb_define_method(rb_cGeoIP2Database, "initialize", rb_geoip2_db_initialize, -1);
+  rb_define_method(rb_cGeoIP2Database, "open_mmdb", rb_geoip2_db_open_mmdb, 1);
   rb_define_method(rb_cGeoIP2Database, "close", rb_geoip2_db_close, 0);
   rb_define_method(rb_cGeoIP2Database, "lookup", rb_geoip2_db_lookup, 1);
 

--- a/ext/geoip2/geoip2.c
+++ b/ext/geoip2/geoip2.c
@@ -418,8 +418,9 @@ rb_geoip2_lr_get_value(int argc, VALUE *argv, VALUE self)
     VALUE array = rb_ary_new();
     VALUE hash;
     VALUE val;
+    bool symbolize_keys = RTEST(rb_iv_get(self, "@symbolize_keys"));
     for (int j = 0; path[j] != NULL; j++) {
-      rb_ary_push(array, rb_str_new_cstr(path[j]));
+      rb_ary_push(array, symbolize_keys ? ID2SYM(rb_intern(path[j])) : rb_str_new_cstr(path[j]));
     }
     hash = rb_funcall(self, rb_intern("to_h"), 0);
     val = rb_apply(hash, rb_intern("dig"), array);

--- a/lib/geoip2/database.rb
+++ b/lib/geoip2/database.rb
@@ -1,4 +1,8 @@
 module GeoIP2
   class Database
+    def initialize(path, symbolize_keys: false)
+      @symbolize_keys = !!symbolize_keys
+      open_mmdb(path)
+    end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,9 +27,9 @@ def mmdb_source_data(name)
 end
 
 def random_ip_addresses(address_mask, n = 10)
-  IPAddr.new(address_mask).to_range.lazy.select {
-    rand(1000) % 7 == 0
-  }.first(n * 100).sample(n)
+  IPAddr.new(address_mask).to_range.each_with_index.lazy.select { |ip, i|
+    i % 7 == 0
+  }.first(n * 100).sample(n).map(&:first)
 end
 
 def random_ip_data(address_mask, n = 10)

--- a/test/test_geoip2.rb
+++ b/test/test_geoip2.rb
@@ -140,6 +140,47 @@ class GeoIP2Test < Test::Unit::TestCase
     end
   end
 
+  sub_test_case "with symbolize_keys" do
+    setup do
+      @db = GeoIP2::Database.new(mmdb_test_data("GeoIP2-City-Test.mmdb"), symbolize_keys: true)
+    end
+
+    teardown do
+      @db.close
+    end
+
+    data do
+      random_ip_data("::81.2.69.142/127")
+    end
+
+    test "London" do |ip|
+      result = @db.lookup(ip).to_h
+      expected = {
+        geoname_id: 2643743,
+        names: {
+         de: "London",
+         en: "London",
+         es: "Londres",
+         fr: "Londres",
+         ja: "ロンドン",
+         "pt-BR": "Londres",
+         ru: "Лондон"
+        }
+      }
+      assert_equal(expected, result[:city])
+    end
+
+    test "get_value still works with string-keys" do
+      result = @db.lookup("81.2.69.142")
+      assert_instance_of(Hash, result.get_value("city", "names"))
+    end
+
+    test "get_value still works with symbol-keys" do
+      result = @db.lookup("81.2.69.142")
+      assert_instance_of(Hash, result.get_value(:city, :names))
+    end
+  end
+
   sub_test_case "connection type" do
     setup do
       @db = GeoIP2::Database.new(mmdb_test_data("GeoIP2-Connection-Type-Test.mmdb"))


### PR DESCRIPTION
`GeoIP2::LookupResult#to_h` uses quite a few string allocations, many of which are just from the same keys like `"city"`, `"country"`, `"en"`, `"de"` etc.

This PR adds a symbolize_keys option to the database initializer - 

```ruby
db = GeoIP2::Database.new("./cities.mmdb", symbolize_keys: true)
db.lookup("86.20.101.6").to_h
=>
{:city=>{:geoname_id=>2657676, :names=>{:en=>"Addlestone"}},
 :continent=>
  {:code=>"EU",
   :geoname_id=>6255148,
   :names=>{:de=>"Europa", :en=>"Europe", :es=>"Europa", :fr=>"Europe", :ja=>"ヨーロッパ", :"pt-BR"=>"Europa", :ru=>"Европа", :"zh-CN"=>"欧洲"}},
 :country=>
  {:geoname_id=>2635167,
   :iso_code=>"GB",
   :names=>
    {:de=>"Vereinigtes Königreich",
     :en=>"United Kingdom",
     :es=>"Reino Unido",
     :fr=>"Royaume Uni",
     :ja=>"英国",
     :"pt-BR"=>"Reino Unido",
     :ru=>"Британия",
     :"zh-CN"=>"英国"}},
 :location=>{:accuracy_radius=>5, :latitude=>51.3688, :longitude=>-0.4853, :time_zone=>"Europe/London"},
 :postal=>{:code=>"KT15"},
 :registered_country=>
  {:geoname_id=>2635167,
   :iso_code=>"GB",
   :names=>
    {:de=>"Vereinigtes Königreich",
     :en=>"United Kingdom",
     :es=>"Reino Unido",
     :fr=>"Royaume Uni",
     :ja=>"英国",
     :"pt-BR"=>"Reino Unido",
     :ru=>"Британия",
     :"zh-CN"=>"英国"}},
 :subdivisions=>
  [{:geoname_id=>6269131,
    :iso_code=>"ENG",
    :names=>{:de=>"England", :en=>"England", :es=>"Inglaterra", :fr=>"Angleterre", :ja=>"イングランド", :"pt-BR"=>"Inglaterra", :ru=>"Англия", :"zh-CN"=>"英格兰"}},
   {:geoname_id=>2636512, :iso_code=>"SRY", :names=>{:en=>"Surrey"}}]}
```

---

This is approx 30% faster, with 2x fewer allocations - at least, according to this microbenchmark:

```ruby
$:.unshift "./lib"
require "geoip2"
require "memory_profiler"
require "benchmark/ips"

# path = "./GeoLite2-Country.mmdb"
path = "./GeoLite2-City.mmdb"

symboldb = ::GeoIP2::Database.new(path, symbolize_keys: true)
stringdb = ::GeoIP2::Database.new(path, symbolize_keys: false)

# Generate 50k (hopefully representative) public ips
srand(1)
ips = Array.new(5_000) { "#{11 + rand(115)}.#{rand(256)}.#{rand(256)}.#{rand(256)}" }

Benchmark.ips do |x|
  x.report("string-keys") do
    ips.each { |ip| stringdb.lookup(ip).to_h }
  end
  x.report("symbol-keys") do
    ips.each { |ip| symboldb.lookup(ip).to_h }
  end

  x.compare!
end

puts "symbol-keys memory:"
MemoryProfiler.report { ips.each { |ip| symboldb.lookup(ip).to_h } }.pretty_print(scale_bytes: true, retained_strings: 0, allocated_strings: 0, detailed_report: false)
puts "string-keys memory:"
MemoryProfiler.report { ips.each { |ip| stringdb.lookup(ip).to_h } }.pretty_print(scale_bytes: true, retained_strings: 0, allocated_strings: 0, detailed_report: false)
```

```
Warming up --------------------------------------
         string-keys     2.000  i/100ms
         symbol-keys     2.000  i/100ms
Calculating -------------------------------------
         string-keys     21.596  (± 4.6%) i/s -    108.000  in   5.007389s
         symbol-keys     28.875  (± 3.5%) i/s -    146.000  in   5.060505s

Comparison:
         symbol-keys:       28.9 i/s
         string-keys:       21.6 i/s - 1.34x  (± 0.00) slower

symbol-keys memory:
Total allocated: 16.43 MB (233603 objects)
Total retained:  0 B (0 objects)

string-keys memory:
Total allocated: 26.77 MB (492052 objects)
Total retained:  0 B (0 objects)
```


---

WDYT? The code-change would be a lot smaller if we forgot about the symbolize_keys option entirely and just enforced symbol-keys everywhere, but I'm guessing you'd rather not have the breaking change?