### PR TITLE
Fix Windows build by migrating to mini_portile2 and bump libmaxminddb to 1.13.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "test/MaxMind-DB"]
 	path = test/MaxMind-DB
 	url = https://github.com/maxmind/MaxMind-DB.git
-[submodule "ext/geoip2/libmaxminddb"]
-	path = ext/geoip2/libmaxminddb
-	url = https://github.com/maxmind/libmaxminddb.git

--- a/ext/geoip2/extconf.rb
+++ b/ext/geoip2/extconf.rb
@@ -1,33 +1,17 @@
 require "mkmf"
-require "rbconfig"
+require "mini_portile2"
 
-libdir = RbConfig::CONFIG["libdir"]
-includedir = RbConfig::CONFIG["includedir"]
+maxminddb_version = "1.13.3"
 
-maxminddb_dir = File.expand_path(File.join(__dir__, "libmaxminddb"))
-gem_root = File.expand_path('..', __dir__)
+recipe = MiniPortile.new("libmaxminddb", maxminddb_version)
+recipe.files = ["https://github.com/maxmind/libmaxminddb/releases/download/#{maxminddb_version}/libmaxminddb-#{maxminddb_version}.tar.gz"]
+recipe.cook
+recipe.activate
 
-if !File.directory?(maxminddb_dir) ||
-   # '.', '..', and possibly '.git' from a failed checkout:
-   Dir.entries(maxminddb_dir).size <= 3
-  Dir.chdir(gem_root) { system('git submodule update --init') } or fail 'Could not fetch maxminddb'
-end
+$INCFLAGS = "-I#{File.join(recipe.path, 'include')} " + $INCFLAGS
+$LDFLAGS << " -L#{File.join(recipe.path, 'lib')} -lmaxminddb"
+$CFLAGS << " -std=c99 -fPIC -fms-extensions -I#{File.join(recipe.path, 'include')}"
 
-Dir.chdir(maxminddb_dir) do
-  system("./bootstrap") or fail "Couldn't run maxminddb `bootstrap`"
-  system({ "CFLAGS" => "-fPIC" }, "./configure", "--disable-shared", "--disable-tests") or fail "Couldn't run maxminddb `configure`"
-  system("make", "clean") or fail "Couldn't run maxminddb `make clean`"
-  system("make") or fail "Couldn't run maxminddb `make`"
-end
-
-header_dirs = [includedir, "#{maxminddb_dir}/include"]
-lib_dirs = [libdir, "#{maxminddb_dir}/src/.libs"]
-
-dir_config("maxminddb", header_dirs, lib_dirs)
 have_func("rb_sym2str", "ruby.h")
-
-$LDFLAGS << " -L#{maxminddb_dir}/src/.libs -lmaxminddb"
-$CFLAGS << " -std=c99 -fPIC -fms-extensions -I#{maxminddb_dir}/src/.libs"
-# $CFLAGS << " -g -O0"
 
 create_makefile("geoip2/geoip2")

--- a/geoip2_c.gemspec
+++ b/geoip2_c.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/geoip2/extconf.rb"]
 
+  spec.add_dependency('mini_portile2', '~> 2.8')
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This commit fixes build failures on Windows (MSYS2) environments by:

1. Bumping libmaxminddb from 1.3.2 to 1.13.3. Older versions (pre-1.7.0) fail to compile with modern GCC toolchains on MSYS2.
2. Replacing git submodules and the `autoreconf` build process with `mini_portile2`. Fetching pre-configured release tarballs bypasses the need for `bootstrap`, ensuring cross-platform stability.